### PR TITLE
ENH: completely re-write the implementation

### DIFF
--- a/LICENSES/superqt
+++ b/LICENSES/superqt
@@ -1,0 +1,28 @@
+
+Copyright (c) 2021, Talley Lambert
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of superqt nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -15,16 +15,20 @@ A minimal example:
 .. code-block:: python
 
 
+
    import threading
    import time
-   import mpl_qtthread.backend
    import matplotlib
    import matplotlib.backends.backend_qt
+   import matplotlib.pyplot as plt
 
-   mpl_qtthread.backend.initialize_qt_teleporter()
+   import mpl_qtthread
+
    matplotlib.use("module://mpl_qtthread.backend_agg")
 
-   import matplotlib.pyplot as plt
+   matplotlib.backends.backend_qt._create_qApp()
+
+   mpl_qtthread.monkeypatch_pyplot()
 
    plt.ion()
 
@@ -39,7 +43,7 @@ A minimal example:
            ax.set_title(f'cycle {j}')
            fig.canvas.draw_idle()
            time.sleep(5)
-
+       print("Done! please close the window")
 
    threading.Thread(target=background).start()
    matplotlib.backends.backend_qt.qApp.exec()

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,4 +6,4 @@ API
    :toctree: _as_gen
    :nosignatures:
 
-   mpl_qtthread.initialize_qt_teleporter
+   mpl_qtthread.monkeypatch_pyplot

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,7 +29,7 @@
 # needs_sphinx = '1.0'
 import sys
 
-sys.path.append(".")
+sys.path.append("./source")
 
 
 # Release mode enables optimizations and other related options.

--- a/mpl_qtthread/__init__.py
+++ b/mpl_qtthread/__init__.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from . import _version
 
 
-
 def monkeypatch_pyplot():
     """
     Monkey patch pyplot to suppress warnings.

--- a/mpl_qtthread/__init__.py
+++ b/mpl_qtthread/__init__.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from . import _version
 
-from .backend import initialize_qt_teleporter  # noqa
 
 
 def monkeypatch_pyplot():

--- a/mpl_qtthread/backend.py
+++ b/mpl_qtthread/backend.py
@@ -17,6 +17,8 @@ except ImportError:
 # Addapted from
 # https://github.com/napari/superqt/blob/ba1ae92bccc282da040281751b71afcbe4c0e302/src/superqt/utils/_ensure_thread.py
 class CallCallable(QtCore.QObject):
+    """Utility class to wrap callable for moving callables to the right thread."""
+
     finished = QtCore.Signal(object)
     instances: List["CallCallable"] = []
 

--- a/mpl_qtthread/backend.py
+++ b/mpl_qtthread/backend.py
@@ -1,171 +1,128 @@
+from concurrent.futures import Future
+
+from typing import Callable, List, Optional
+
 import threading
 import functools
 
-from matplotlib.figure import Figure
 
 from matplotlib.backends.qt_compat import QtCore
 
 try:
-    from matplotlib.backends.backend_qt import _BackendQT, _create_qApp
+    from matplotlib.backends.backend_qt import _BackendQT
 except ImportError:
-    from matplotlib.backends.backend_qt5 import _BackendQT5 as _BackendQT, _create_qApp
+    from matplotlib.backends.backend_qt5 import _BackendQT5 as _BackendQT
 
-# The purpose of initialize_qt_teleporter, _get_teleporter is to ensure that Qt
-# GUI events are processed on the main thread.
-# this is adapted from github.com/bluesky/bluesky
 
-_teleporter = None
+# Addapted from
+# https://github.com/napari/superqt/blob/ba1ae92bccc282da040281751b71afcbe4c0e302/src/superqt/utils/_ensure_thread.py
+class CallCallable(QtCore.QObject):
+    finished = QtCore.Signal(object)
+    instances: List["CallCallable"] = []
+
+    def __init__(self, callable, *args, **kwargs):
+        super().__init__()
+        self._callable = callable
+        self._args = args
+        self._kwargs = kwargs
+        CallCallable.instances.append(self)
+
+    @QtCore.Slot()
+    def call(self):
+        CallCallable.instances.remove(self)
+        res = self._callable(*self._args, **self._kwargs)
+        self.finished.emit(res)
+
+
+def ensure_main_thread(
+    func: Optional[Callable] = None, await_return: bool = True, timeout: int = 5
+):
+    """Decorator that ensures a function is called in the main QApplication thread.
+    It can be applied to functions or methods.
+    Parameters
+    ----------
+    func : callable
+        The method to decorate, must be a method on a QObject.
+    await_return : bool, optional
+        Whether to block and wait for the result of the function, or return immediately.
+        by default True
+    timeout : float, optional
+        If `await_return` is `True`, time (in seconds) to wait for the result
+        before raising a TimeoutError, by default 5
+    """
+
+    def _out_func(func_):
+        @functools.wraps(func_)
+        def _func(*args, **kwargs):
+            return _run_in_thread(
+                func_,
+                QtCore.QCoreApplication.instance().thread(),
+                await_return,
+                timeout,
+                *args,
+                **kwargs,
+            )
+
+        return _func
+
+    if func is None:
+        return _out_func
+    return _out_func(func)
+
+
+def _run_in_thread(
+    func: Callable,
+    thread: QtCore.QThread,
+    await_return: bool,
+    timeout: int,
+    *args,
+    **kwargs,
+):
+    future = Future()  # type: ignore
+    if thread is QtCore.QThread.currentThread():
+        result = func(*args, **kwargs)
+        if not await_return:
+            future.set_result(result)
+            return future
+        return result
+    f = CallCallable(func, *args, **kwargs)
+    f.moveToThread(thread)
+    f.finished.connect(future.set_result, QtCore.Qt.ConnectionType.DirectConnection)
+    QtCore.QMetaObject.invokeMethod(f, "call", QtCore.Qt.ConnectionType.QueuedConnection)  # type: ignore
+    return future.result(timeout=timeout) if await_return else future
 
 
 class FigureCanvasQT(_BackendQT.FigureCanvas):
     def flush_events(self):
         # only try to flush events if we are on main thread
         if threading.current_thread() is threading.main_thread():
-            super().flush_events()
+            return super().flush_events()
 
     def start_event_loop(self, timeout=0):
         # only try to flush events if we are on main thread
         if threading.current_thread() is threading.main_thread():
-            super().start_event_loop(timeout=timeout)
+            return super().start_event_loop(timeout=timeout)
 
 
 class FigureManagerQT(_BackendQT.FigureManager):
-    def _orig_destroy(self):
-        super().destroy()
-
+    @ensure_main_thread
     def destroy(self):
-        if _teleporter is None:
-            raise RuntimeError("teleporter not inited")
-        evt = threading.Event()
+        return super().destroy()
 
-        _teleporter.destroy_manager.emit(self, evt)
-
-        if not evt.wait(5):
-            raise RuntimeError("failed to destroy manager.")
-
-    def _orig_resize(self, width, height):
-        super().resize(width, height)
-
+    @ensure_main_thread
     def resize(self, width, height):
-        if _teleporter is None:
-            raise RuntimeError("teleporter not inited")
-        evt = threading.Event()
+        return super().resize(width, height)
 
-        _teleporter.resize_manager.emit(self, width, height, evt)
-
-        if not evt.wait(5):
-            raise RuntimeError("failed to destroy manager.")
-
-    def _orig_show(self):
-        super().show()
-
+    @ensure_main_thread
     def show(self):
-        if _teleporter is None:
-            raise RuntimeError("teleporter not inited")
-        evt = threading.Event()
-
-        _teleporter.show_manager.emit(self, evt)
-
-        if not evt.wait(5):
-            raise RuntimeError("failed to destroy manager.")
-
-
-def initialize_qt_teleporter():
-    """
-    Set up the Qt 'teleporter' to move widget creation to the main thread.
-
-    This makes it safe to create Matplotlib figures from threads other than the
-    main one.
-
-    .. warning ::
-
-        This must be run on the main thread.
-
-    Raises
-    ------
-    RuntimeError
-        If called from any thread but the main thread
-
-    """
-    global _teleporter
-    if _build_teleporter.cache_info().currsize:
-        # Already initialized.
-        return
-    if threading.current_thread() is not threading.main_thread():
-        raise RuntimeError(
-            "initialize_qt_teleporter() may only be called from the main " "thread."
-        )
-    # first make sure we have the q
-    _create_qApp()
-    _teleporter = _build_teleporter()
-
-
-# make sure we only do this once
-@functools.lru_cache(maxsize=1)
-def _build_teleporter():
-    # TODO sort out what this does with QThreads
-    if threading.current_thread() is not threading.main_thread():
-        raise RuntimeError("Must initialize teleporter on main thread!")
-
-    class Teleporter(QtCore.QObject):
-        create_widget = QtCore.Signal(Figure, type, threading.Event)
-        # TODO make the second argument int or str
-        create_manager = QtCore.Signal(Figure, int, type, threading.Event)
-        destroy_manager = QtCore.Signal(FigureManagerQT, threading.Event)
-        resize_manager = QtCore.Signal(FigureManagerQT, float, float, threading.Event)
-        show_manager = QtCore.Signal(FigureManagerQT, threading.Event)
-
-    t = Teleporter()
-
-    @t.create_widget.connect
-    def create_widget(figure, canvas_class, evt):
-        # do not worry, circular references mean the canvas gets put
-        # on the figure here!
-        canvas_class(figure)
-        evt.set()
-
-    @t.create_manager.connect
-    def create_manager(figure, num, manager_class, evt):
-        # Again, we are relying on circular references to stash the newly
-        # created object
-        manager_class(figure.canvas, num)
-        evt.set()
-
-    @t.destroy_manager.connect
-    def destroy_manager(manager, evt):
-        manager._orig_destroy()
-        evt.set()
-
-    @t.resize_manager.connect
-    def resize_manager(manager, width, height, evt):
-        manager._orig_resize(width, height)
-        evt.set()
-
-    @t.show_manager.connect
-    def show_manager(manager, evt):
-        manager._orig_show()
-        evt.set()
-
-    return t
+        return super().show()
 
 
 class _BackendThreads(_BackendQT):
     @classmethod
+    @ensure_main_thread
     def new_figure_manager_given_figure(cls, num, figure):
-        if _teleporter is None:
-            raise RuntimeError("teleporter not inited")
-        evt = threading.Event()
-        _teleporter.create_widget.emit(figure, cls.FigureCanvas, evt)
-        if not evt.wait(5):
-            raise RuntimeError("failed to create canvas")
-
-        canvas = figure.canvas
-        evt = threading.Event()
-        _teleporter.create_manager.emit(figure, num, cls.FigureManager, evt)
-        if not evt.wait(5):
-            raise RuntimeError("failed to create manager")
-
-        return canvas.manager
+        return super().new_figure_manager_given_figure(num, figure)
 
     FigureManager = FigureManagerQT
     FigureCanvas = FigureCanvasQT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # List required packages in this file, one per line.
 matplotlib
-pyqt5
+pyqt6


### PR DESCRIPTION
Closes #2 (by adopting a vendored version of the superqt implementation)

Closes #1 (because the teleporter no longer exists)

In the (old) teleporter version we would create one QObject per process which
had several (very custom) signals on it for each of the things we need to do
that needs to be created on the correct thread.  In the (new) superqt method we
cerate a new QObject per call and then ship it to the correct thread at call
time.